### PR TITLE
Add recursive include resolution with guard detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,18 +86,29 @@ function viteSlang(options) {
             throw new Error(`Unable to create Slang session for ${options.target} target. Please file an issue.`)
           }
 
-          /** @type {import('./slang-2025.15-wasm/slang-wasm.js').Module | null} */
-          const module = session.loadModuleFromSource(
-            // Resolve #include directives
-            code.replaceAll(IMPORT_REGEX, (match, specifier) => {
+          // Recursively resolve #include directives
+          // Files with include guards (#ifndef) are only included once.
+          // Files without guards (template-pattern headers) can be re-included.
+          const resolved = new Set()
+          const resolveIncludes = (source, baseDir) => {
+            return source.replaceAll(IMPORT_REGEX, (match, specifier) => {
               try {
-                const file = path.resolve(path.dirname(id), specifier)
+                const file = path.resolve(baseDir, specifier)
                 this.addWatchFile(file)
-                return fs.readFileSync(file, { encoding: 'utf8' })
+                const content = fs.readFileSync(file, { encoding: 'utf8' })
+                const hasGuard = /^\s*#ifndef\s+(\w+)\s*\n\s*#define\s+\1\b/m.test(content)
+                if (hasGuard && resolved.has(file)) return `// [already included: ${specifier}]`
+                if (hasGuard) resolved.add(file)
+                return resolveIncludes(content, path.dirname(file))
               } catch {
                 return match
               }
-            }),
+            })
+          }
+
+          /** @type {import('./slang-2025.15-wasm/slang-wasm.js').Module | null} */
+          const module = session.loadModuleFromSource(
+            resolveIncludes(code, path.dirname(id)),
             'shader',
             id,
           )


### PR DESCRIPTION
## Summary

- `#include` directives are now resolved recursively, so nested headers (e.g., OpenPBR's multi-file BSDF library) work correctly
- Files with include guards (`#ifndef FOO / #define FOO`) are only included once, preventing duplicate definition errors
- Files without guards (template-pattern headers) can be re-included as needed

## Motivation

The current flat include resolution breaks when shader libraries use nested `#include` chains. For example, the [OpenPBR BSDF](https://github.com/adobe/openpbr-bsdf) reference implementation has `openpbr.h` → `openpbr_api.h` → `openpbr_impl.h` → many more files. Without recursive resolution, only the first level of includes is inlined and the Slang compiler fails with "failed to find include file" errors.

## Live demos using this patch

- [WebGPU Path Tracer Viewer](https://zalo.github.io/three-gpu-pathtracer/webgpu-viewer.html) — drag-and-drop GLTF viewer with Slang compute shaders
- [Material Gallery](https://zalo.github.io/three-gpu-pathtracer/webgpu-material.html) — multiple models with OpenPBR materials
- [Basic Primitives](https://zalo.github.io/three-gpu-pathtracer/webgpu-basic.html) — minimal three.js integration

Source: [zalo/three-gpu-pathtracer](https://github.com/zalo/three-gpu-pathtracer/tree/feature/slang-webgpu-pathtracer)

## Test plan

- [x] Verified recursive includes work with OpenPBR's 9000+ line multi-file header chain
- [x] Include guards prevent duplicate definitions
- [x] Non-guarded headers (template pattern) can be included multiple times
- [x] Existing single-level includes still work (backward compatible)
- [x] Production `vite build` succeeds (previously failed in CI)